### PR TITLE
Backport changes from cookiecutter-django-girder v0.3

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -13,7 +13,8 @@ ENV PYTHONUNBUFFERED 1
 # but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
-COPY ./setup.py /opt/django/setup.py
-RUN pip install --editable /opt/django[dev]
+COPY ./setup.py /opt/django-project/setup.py
+RUN pip install --editable /opt/django-project[dev]
 
-WORKDIR /opt/django
+# Use a directory name which will never be an import name, as isort considers this as first-party.
+WORKDIR /opt/django-project

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,9 +5,11 @@ services:
       context: .
       dockerfile: ./dev/django.Dockerfile
     command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    # Log printing via Rich is enhanced by a TTY
+    tty: true
     env_file: ./dev/.env.docker-compose
     volumes:
-      - .:/opt/django
+      - .:/opt/django-project
     ports:
       - 8000:8000
     depends_on:
@@ -25,9 +27,11 @@ services:
       "--loglevel", "info",
       "--without-heartbeat"
     ]
+    # Docker Compose does not set the TTY width, which causes Celery errors
+    tty: false
     env_file: ./dev/.env.docker-compose
     volumes:
-      - .:/opt/django
+      - .:/opt/django-project
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
https://github.com/girder/cookiecutter-django-girder/releases/tag/v0.3